### PR TITLE
Use MkdirAll for icon directory

### DIFF
--- a/icon.go
+++ b/icon.go
@@ -63,7 +63,7 @@ func installGrowlIcons() {
 	dir := getIconDir()
 	_, err := os.Stat(dir)
 	if err != nil {
-		if os.Mkdir(dir, 0700) != nil {
+		if os.MkdirAll(dir, 0700) != nil {
 			log.Fatal("failed to create directory: ", err)
 		}
 	}


### PR DESCRIPTION
In my environment, `gomon -install-growl-icons` failed with following error.

```
$ gomon -install-growl-icons
2013/07/15 21:52:45 failed to create directory: stat /Users/kawachi/.gomon/gomon: no such file or directory
```
