### PR TITLE
Cancel running jobs when new changes arrive.

### DIFF
--- a/delay.go
+++ b/delay.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/c9s/gomon/logger"
+)
+
+const delayWait time.Duration = 500 * time.Millisecond
+
+type DelayResult struct {
+	duration time.Duration
+	err      error
+}
+
+// Wraps JobRunner so that we only call it every delayWait
+// duration. Used since file changes often come in batches
+// (e.g. go fmt & the vim plugin), and since we also want to support
+// cancelling running jobs.
+type Delay struct {
+	jobRunner    *JobRunner
+	alwaysNotify bool
+	jobs         chan string
+	results      chan DelayResult
+	wait         sync.WaitGroup
+}
+
+func NewDelay(jobRunner *JobRunner, alwaysNotify bool) *Delay {
+	return &Delay{
+		jobRunner:    jobRunner,
+		alwaysNotify: alwaysNotify,
+		jobs:         make(chan string),
+		results:      make(chan DelayResult),
+	}
+}
+
+// Logs results of command run after completion, with
+// a little extra logic to detect cancellation.
+func (d *Delay) logResult(ctx context.Context) {
+	var result DelayResult
+	var interrupted bool
+	select {
+	case <-ctx.Done():
+		// Context was cancelled before result came in.
+		// We must still wait for results, though!
+		interrupted = true
+		result = <-d.results
+	case result = <-d.results:
+	}
+
+	switch {
+	case interrupted:
+		logger.Infoln("Command was killed and restarted...")
+	case result.err != nil:
+		logger.Errorf("Command failed: %v", result.err.Error())
+	default:
+		logger.Infoln("Command succeeded:", result.duration)
+	}
+}
+
+// Triggers delayed execution for a given file event.
+// NB: only the most recent file in a 500ms batch will be used.
+func (d *Delay) Trigger(filename string) {
+	d.jobs <- filename
+}
+
+// Rolls up triggers into a single run of the job runner every
+// delayWait duration, with logic for cancelling any active job.
+func (d *Delay) Run() {
+	filename := ""
+	ctx, cancel := context.WithCancel(context.Background())
+	for {
+		select {
+		case <-time.After(delayWait):
+			if filename == "" {
+				continue
+			}
+
+			//Cancel any running job and wait for it to exit.
+			cancel()
+			d.wait.Wait()
+
+			// Construct new context and execute job.
+			ctx, cancel = context.WithCancel(context.Background())
+			go func(ctx context.Context, filename string) {
+				d.wait.Add(1)
+				defer cancel()
+				defer d.wait.Done()
+				duration, err := d.jobRunner.RunAndNotify(ctx, filename, d.alwaysNotify)
+				d.results <- DelayResult{duration, err}
+			}(ctx, filename)
+
+			go d.logResult(ctx)
+			filename = ""
+
+		case filename = <-d.jobs:
+		}
+	}
+}

--- a/job_runner.go
+++ b/job_runner.go
@@ -30,15 +30,15 @@ func (r *JobRunner) RunAndNotify(ctx context.Context, filename string, alwaysNot
 		r.previouslyFailed = true
 		r.mu.Unlock()
 
-		notifier.NotifyFailed("Build failed", err.Error())
+		notifier.NotifyFailed("Command failed", err.Error())
 	} else {
 		r.mu.Lock()
 		if r.previouslyFailed {
 			r.previouslyFailed = false
 
-			notifier.NotifyFixed("Build fixed", fmt.Sprintf("Spent: %s", duration))
+			notifier.NotifyFixed("Command recovered from prior failure", fmt.Sprintf("Spent: %s", duration))
 		} else if alwaysNotify {
-			notifier.NotifySucceeded("Build succeeded", fmt.Sprintf("Spent: %s", duration))
+			notifier.NotifySucceeded("Command succeeded", fmt.Sprintf("Spent: %s", duration))
 		}
 		r.mu.Unlock()
 	}


### PR DESCRIPTION
Hey! Thanks both for maintaining gomon. I hope you find this PR a helpful change -- please let me know if there's anything I can change. Commit message follows:

Although gomon's JobRunner supports cancellation, its invocation was
wrapped in a Once() call, such that in fact gomon never actually
cancelled running jobs. Fix this by constructing an explicit
delay runner which:

1. Supports triggering with new filenames at any time,
2. Results in job execution no later than 500ms after a new
   file event, and
3. Cancels any existing job when a new job is started.

For the common case, this seems to be the right path: even if you had a
long running build, you'd still want to restart the build given that you
had new files.

This also supports a second case of using gomon to auto-reload a server.
This use case was hinted at in the README's example

```
gomon src -- go run -x server.go
```

but only works with a change like the one in this commit -- i.e. one
where starting a new job cancels the existing, running job.